### PR TITLE
Update DataEngineProd collection to new name

### DIFF
--- a/api-guides/search.mdx
+++ b/api-guides/search.mdx
@@ -51,7 +51,7 @@ Once you have your tenant name, you're ready to query the search endpoint. You c
 curl 'https://platform.ai.gloo.com/ai/v1/kallm/search' -v \
   -H 'Content-Type: application/json' \
   -H "Authorization: Bearer ${ACCESS_TOKEN}" \
-  -d '{"search":"How can I become a better parent?","collection":"DataEngineProd","tenant": "TestOrg", "limit":1}'
+  -d '{"search":"How can I become a better parent?","collection":"GlooProd","tenant": "TestOrg", "limit":1}'
 ```
 
 Example Response
@@ -372,7 +372,7 @@ The result should look something like this:
       },
       "references": null,
       "vector": {},
-      "collection": "DataEngineProd"
+      "collection": "GlooProd"
     }
   ],
   "intent": 1

--- a/api-guides/search.mdx
+++ b/api-guides/search.mdx
@@ -30,7 +30,7 @@ When constructing an AI application, it is sometimes useful to provide additiona
 Before making a request, you must know which publisher's content you would like to query.
 
 1.  **Find Your Tenant (Publisher Name):** First, navigate to the [Organizations page](/studio/manage-organizations) in Studio and click "View Publishers". Your **Tenant** is the name of the publisher you're querying.
-2.  **Identify the Collection:** A collection is where we keep the content for our customers. The only collection you'll need to specify in requests is `DataEngineProd`. You must specify this in the `collection` field.
+2.  **Identify the Collection:** A collection is where we keep the content for our customers. The only collection you'll need to specify in requests is `GlooProd`. You must specify this in the `collection` field.
 
 <Info>
 **NOTE:** You will only have access to your own publisher's tenant through this endpoint, and a tenant must be specified. Other requests will result in a 403 "Forbidden" response.


### PR DESCRIPTION
<!-- adapted from https://github.com/TangoGroup/gloo/blob/ebd17c1/.github/pull_request_template.md -->

### 👉 TLDR: (short summary of changes)

DataEngineProd is now GlooProd

---

### 👀 Reviewer Checklist

Please do not approve this pull request until all of the following items are checked:

- [ ] Does this pull request have a Linear ticket linked to it? (Required for SOC2)

Per agreement with @brianjohnson0123 no linear ticket needed

---

### 🗣️ Details

Per request from Keane, update the collection name in the search guide as DataEngineProd is now GlooProd.

---

### ✅ How to verify

- Go to the search page under API guide.
- You should not see DataEngineProd. Instead it should be GlooProd.

---

### 🎬 Keeping Things Current

![](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExejRheG9xdDUyc3lvM3c4NHdxank2ODdueWdvamc5YXZhNWY3cWI2eCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Xf8D9Qf8OCKnMvNnru/giphy.gif)
